### PR TITLE
fix: create id field on models in collections

### DIFF
--- a/src/mcp_server_replicate/replicate_client.py
+++ b/src/mcp_server_replicate/replicate_client.py
@@ -607,6 +607,7 @@ class ReplicateClient:
                 "description": data.get("description"),
                 "models": [
                     {
+                        "id": f"{model['owner']}/{model['name']}",
                         "owner": model["owner"],
                         "name": model["name"],
                         "description": model.get("description"),


### PR DESCRIPTION
When getting the details of a collection, we get an error like the following:
```
Error executing tool get_collection_details: 7 validation errors for Collection
models.0.id
  Field required [type=missing, input_value={'owner': 'lucataco', 'na... 'An enumeration.'}}}}}}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
models.1.id
  Field required [type=missing, input_value={'owner': 'nateraw', 'nam...title': 'Detail'}}}}}}}}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
models.2.id
  Field required [type=missing, input_value={'owner': 'zsxkib', 'name...title': 'Detail'}}}}}}}}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
models.3.id
  Field required [type=missing, input_value={'owner': 'zsxkib', 'name... 'An enumeration.'}}}}}}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
models.4.id
  Field required [type=missing, input_value={'owner': 'replicate', 'n...title': 'Detail'}}}}}}}}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
models.5.id
  Field required [type=missing, input_value={'owner': 'pseudoram', 'n...title': 'Detail'}}}}}}}}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
models.6.id
  Field required [type=missing, input_value={'owner': 'zsxkib', 'name... 'An enumeration.'}}}}}}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
    ```
    
 This fixes by creating an `id` field from owner and name on each model so they match the expected structure of `Model`. 