### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 A FastMCP server implementation for the Replicate API, providing resource-based access to AI model inference with a focus on image generation.
 
+<a href="https://glama.ai/mcp/servers/r830bzsk7r"><img width="380" height="200" src="https://glama.ai/mcp/servers/r830bzsk7r/badge" alt="Server Replicate MCP server" /></a>
+
 ## Features
 
 - 🖼️ Resource-based image generation and management


### PR DESCRIPTION
This PR adds a badge for the [MCP Server Replicate](https://glama.ai/mcp/servers/r830bzsk7r) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/r830bzsk7r"><img width="380" height="200" src="https://glama.ai/mcp/servers/r830bzsk7r/badge" alt="Server Replicate MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.