### PR TITLE
Deployment: Dockerfile and Smithery config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Use the official Python image with a version that matches our needs
+FROM python:3.11-slim-bookworm AS base
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the pyproject.toml and the lock file to the container
+COPY pyproject.toml uv.lock /app/
+
+# Install UV for dependency management
+RUN pip install uv
+
+# Install the dependencies using UV
+RUN uv sync --frozen --no-install-project --no-dev --no-editable
+
+# Copy the project files into the container
+COPY src/ /app/src/
+
+# Ensure the entrypoint is executable
+RUN chmod +x /app/src/mcp_server_replicate/__main__.py
+
+# Specify the command to run the MCP server
+CMD ["uv", "tool", "run", "mcp-server-replicate"]
+
+# Set environment variable for API token (to be overridden when running the container)
+ENV REPLICATE_API_TOKEN=your_api_key_here

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Type Checker](https://img.shields.io/badge/type%20checker-mypy-blue.svg)](https://github.com/python/mypy)
 [![Ruff](https://img.shields.io/badge/linter-ruff-red.svg)](https://github.com/astral-sh/ruff)
 [![PyPI version](https://badge.fury.io/py/mcp-server-replicate.svg)](https://pypi.org/project/mcp-server-replicate/)
+[![smithery badge](https://smithery.ai/badge/@gerred/mcp-server-replicate)](https://smithery.ai/server/@gerred/mcp-server-replicate)
 
 A FastMCP server implementation for the Replicate API, providing resource-based access to AI model inference with a focus on image generation.
 
@@ -53,6 +54,15 @@ Create a photorealistic mountain landscape at sunset with snow-capped peaks, qua
 
 ## Installation
 
+### Installing via Smithery
+
+To install MCP Server Replicate for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@gerred/mcp-server-replicate):
+
+```bash
+npx -y @smithery/cli install @gerred/mcp-server-replicate --client claude
+```
+
+### Installing Manually
 You can install the package directly from PyPI:
 
 ```bash

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,17 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - replicateApiToken
+    properties:
+      replicateApiToken:
+        type: string
+        description: The API key for the Replicate server.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({ command: 'uv', args: ['tool', 'run', 'mcp-server-replicate'], env: { REPLICATE_API_TOKEN: config.replicateApiToken } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Dockerfile**: Introduces a Dockerfile to package the MCP for deployment across various environments.
- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. This file is used by [Smithery](https://smithery.ai?utm_campaign=pr) to render configurations for the end-user. It also allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to Smithery, serving it over SSE so end-users do not need to install additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/@gerred/mcp-server-replicate?utm_campaign=pr&modal=claim), claiming it and clicking "Deploy".
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. Note that the installation only works after the server is deployed.

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let us know if you have any questions. 🙂